### PR TITLE
Check for Bash shell at least v4

### DIFF
--- a/tmuxer
+++ b/tmuxer
@@ -2,6 +2,17 @@
 
 set -euo pipefail
 
+die () {
+    printf '%s\n' "$1" >&2
+    exit 1
+}
+
+MAJOR_BASH_VERSION=$(echo $BASH_VERSION | cut -d '.' -f 1)
+if [[ $MAJOR_BASH_VERSION < 4 ]]
+then
+  die "You must use a Bash shell that is >= version 4 (you're on $BASH_VERSION)"
+fi
+
 # default vars
 readonly _TMUXER_SUBST_STRING="{}"
 readonly _TMUXER_DEFAULT_CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/tmuxer"
@@ -20,10 +31,6 @@ TMUXER_NEW_SESSION=0
 TMUXER_DISABLE_SYNC=0
 TMUXER_DUMP_CONFIG=0
 
-die () {
-    printf '%s\n' "$1" >&2
-    exit 1
-}
 
 print_help () {
     cat <<USAGE_EOF


### PR DESCRIPTION
MacOS ships with bash3 by default. For this script to work, users need to install at least version 4. At the time of writing, installing via homebrew will install v5.

```
❯ tmuxer -l tiled -c "ssh {}" foo bar
You must use a Bash shell that is at least version 4 (you're on 3.2.57(1)-release)
```